### PR TITLE
Remove check for deleted vertices

### DIFF
--- a/src/firewheel_repo_dns/populate_zones/plugin.py
+++ b/src/firewheel_repo_dns/populate_zones/plugin.py
@@ -54,8 +54,6 @@ class PopulateZones(AbstractPlugin):
 
         vertices = self.g.get_vertices()
         for vertex in vertices:
-            if vertex.get("deleted"):
-                continue
             if not vertex.is_decorated_by(Switch):
                 full_name = vertex.name
                 name = full_name.split(".")


### PR DESCRIPTION
The `"deleted"` key does not appear to be set on the Vertex (which also does not implement the `get` method). This removes the check from the zone population plugin, ideally with minimal consequences as this key does not appear to be set or used in any of the primary class of model components.