### PR TITLE
ci: Refer CI to reusable workflows in the FIREWHEEL CI repo

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,0 +1,141 @@
+# This release drafter follows the conventions
+# from https://keepachangelog.com
+
+name-template: 'v$RESOLVED_VERSION'
+tag-template: 'v$RESOLVED_VERSION'
+template: |
+  $CHANGES
+
+  **Full Changelog**: https://github.com/$OWNER/$REPOSITORY/compare/$PREVIOUS_TAG...v$RESOLVED_VERSION
+
+categories:
+  - title: 🚀 Features
+    labels:
+      - feature
+      - enhancement
+  - title: 🐛 Bug Fixes
+    labels:
+      - fix
+      - bug
+  - title: ⚠️ Changes
+    labels:
+      - changed
+      - chore
+      - style
+      - refactor
+      - test
+      - perf
+      - chore
+  - title: ⚙️  Build/CI
+    labels:
+      - ci
+      - build
+  - title: ⛔️ Deprecated
+    labels:
+      - deprecated
+  - title: 🗑 Removed
+    labels:
+      - removed
+  - title: 🔐 Security
+    labels:
+      - security
+  - title: 📄 Documentation
+    labels:
+      - docs
+      - documentation
+  - title: 🧩 Dependency Updates
+    labels:
+      - deps
+      - dependencies
+    collapse-after: 5
+
+change-template: '- $TITLE @$AUTHOR ([#$NUMBER]($URL))'
+change-title-escapes: '\<*_&' # You can add # and @ to disable mentions, and add ` to disable code blocks.
+version-resolver:
+  major:
+    labels:
+      - major
+  minor:
+    labels:
+      - minor
+  patch:
+    labels:
+      - patch
+  default: patch
+
+exclude-labels:
+  - skip-changelog
+
+autolabeler:
+  - label: 'feature'
+    branch:
+      - /(feature|feat)[-\/].+/
+    title:
+      - /(feature|feat)[:].+/
+  - label: 'fix'
+    branch:
+      - /(fix|bug|bugfix)[-/].+/
+    title:
+      - /(fix|bug|bugfix)[:].+/
+  - label: 'documentation'
+    branch:
+      - /(documentation|doc|docs)[-/].+/
+    title:
+      - /(documentation|doc|docs)[:].+/
+    files:
+      - '*.rst'
+  - label: 'style'
+    branch:
+      - /(style)[-/].+/
+    title:
+      - /(style)[:].+/
+  - label: 'refactor'
+    branch:
+      - /(refactor)[-/].+/
+    title:
+      - /(refactor)[:].+/
+  - label: 'ci'
+    branch:
+      - /(ci)[-/].+/
+    title:
+      - /(ci)[:].+/
+  - label: 'chore'
+    branch:
+      - /(chore)[-/].+/
+    title:
+      - /(chore)[:].+/
+  - label: 'refactor'
+    branch:
+      - /(refactor)[-/].+/
+    title:
+      - /(refactor)[:].+/
+  - label: 'perf'
+    branch:
+      - /(perf|performance)[-/].+/
+    title:
+      - /(perf|performance)[:].+/
+  - label: 'test'
+    branch:
+      - /(test|testing|tests)[-/].+/
+    title:
+      - /(test|testing|tests)[:].+/
+  - label: 'build'
+    branch:
+      - /(build)[-/].+/
+    title:
+      - /(build)[:].+/
+  - label: 'revert'
+    branch:
+      - /(revert)[-/].+/
+    title:
+      - /(revert)[:].+/
+  - label: 'dependencies'
+    branch:
+      - /(dependencies|deps)[-/].+/
+    title:
+      - /(dependencies|deps)[:].+/
+  - label: 'security'
+    branch:
+      - /(sec|security)[-/].+/
+    title:
+      - /(sec|security)[:].+/

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -1,6 +1,6 @@
 # This workflow will enforce FIREWHEEL ecosystem standard linting
 
-name: FIREWHEEL Linting
+name: Lint
 
 on:
   push:
@@ -10,4 +10,8 @@ on:
 
 jobs:
   call-firewheel-linting:
-    uses: sandialabs/firewheel/.github/workflows/linting.yml@main
+    name: FIREWHEEL linting
+    # Use the FIREWHEEL CI repo for both the workflow and its composite actions
+    uses: sandialabs/firewheel_ci/.github/workflows/linting.yml@main
+    with:
+      actions-ref: main

--- a/.github/workflows/pr-title-checker.yml
+++ b/.github/workflows/pr-title-checker.yml
@@ -1,0 +1,17 @@
+name: Check Pull Request Title
+
+on:
+  pull_request:
+    types:
+      - opened
+      - edited
+      - synchronize
+      - reopened
+
+jobs:
+  call-firewheel-pr-title-checker:
+    name: Validate FIREWHEEL PR title
+    uses: sandialabs/firewheel_ci/.github/workflows/pr-title-checker.yml@main
+
+permissions:
+  pull-requests: read

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -1,16 +1,17 @@
 # This workflow will upload a Python package in the official FIREWHEEL ecosystem
 
-name: Upload FIREHWEEL Python Package
+name: Publish Python Package
 
 on:
   release:
     types: [published]
 
-permissions:
-  contents: read
-
 jobs:
-  call-firewheel-python-publish:
-    uses: sandialabs/firewheel/.github/workflows/python-publish.yml@main
+  call-firewheel-publishing:
+    name: Publish FIREWHEEL packages
+    uses: sandialabs/firewheel_ci/.github/workflows/python-publish.yml@main
     secrets:
       PYPI_API_TOKEN: ${{ secrets.PYPI_API_TOKEN }}
+
+permissions:
+  contents: read

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -1,0 +1,25 @@
+name: Draft Release
+
+on:
+  push:
+    branches:
+      - main
+  pull_request_target:
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - labeled
+      - unlabeled
+
+jobs:
+  call-firewheel-release-drafter:
+    name: Update release notes (FIREWHEEL-style)
+    permissions:
+      contents: write
+      pull-requests: write
+      checks: write
+    uses: sandialabs/firewheel_ci/.github/workflows/release-drafter.yml@main
+
+permissions:
+  contents: read

--- a/.github/workflows/update-changelog.yml
+++ b/.github/workflows/update-changelog.yml
@@ -1,0 +1,15 @@
+name: Update Changelog
+
+on:
+  release:
+    types: [released]
+
+jobs:
+  call-firewheel-update-changelog:
+    name: Update Changelog (FIREWHEEL-style)
+    permissions:
+      contents: write
+    uses: sandialabs/firewheel_ci/.github/workflows/update-changelog.yml@main
+
+permissions:
+  contents: read

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,77 +1,13 @@
 ###############################
-# FIREWHEEL's Continuous Integration
-#
-# This GitLab CI file enables testing of FIREWHEEL
-# on a variety of operating systems and versions of
-# Python.
-#
-# It makes heavy use of Anchors to save space.
-# see: https://docs.gitlab.com/ce/ci/yaml/README.html#anchors
-#
+# CI: `firewheel_repo_dns`
 ###############################
-
-###############################
-# Change pip's cache directory to be inside the project
-# directory since we can only cache local items.
-###############################
-variables:
-  PIP_CACHE_DIR: "$CI_PROJECT_DIR/.cache/pip"
-
-
-###############################
-# Pip's cache doesn't store the python packages
-# https://pip.pypa.io/en/stable/reference/pip_install/#caching
-#
-# If you want to also cache the installed packages, you have to install
-# them in a virtualenv and cache it as well.
-###############################
-cache:
-  paths:
-    - .cache/pip
-    - fwpy/
-
-
-before_script:
-  - pushd /tmp
-  - python3.8 -m venv fwpy
-  - source fwpy/bin/activate
-  - popd
-  - python -m pip install $PIP_ARGS --upgrade wheel setuptools pip
-  - python -m pip install $PIP_ARGS pip --upgrade
-  - python -m pip install $PIP_ARGS tox
-
-
-###############################
-# Creating a few defaults and setting up the Pipeline stages.
-###############################
-default:
-  tags:
-    - ubuntu1804
 
 stages:
-  - lint
   - upstream
 
-###############################
-# Lint Stages
-#
-# This includes:
-# * lint-code: Linting all executable code
-# * lint-docs: Linting all documentation
-###############################
-lint-code:
-  stage: lint
-  script:
-    - tox -e lint
-
-lint-docs:
-  stage: lint
-  script:
-    - tox -e lint-docs
-
-# Trigger our downstream FIREWHEEL pipeline.
-update-docs:
+# Trigger CI for FIREWHEEL
+firewheel-ci:
   stage: upstream
   trigger: firewheel/firewheel
   only:
-    - master
+    - main

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,19 +4,5 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
-
-### Added
-
-### Changed
-
-### Deprecated
-
-### Removed
-
-### Fixed
-
-### Security
-
 # [2.7.0] - 2024-12-12
 This is the initial Open Source release of ``firewheel_repo_dns``!

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -1,0 +1,16 @@
+.. _contributor_guide:
+
+Contributor Guide
+=================
+
+FIREWHEEL is an open source project and we welcome contributions from the community.
+New ideas and better solutions to existing code are always welcome!
+
+As a tool within the FIREWHEEL ecosystem, the FIREWHEEL developers apply the same contribution guidelines and expectations to this model component (MC) as the FIREWHEEL package.
+Those guidelines are detailed completely in the `root FIREWHEEL repository <https://github.com/sandialabs/firewheel/blob/main/CONTRIBUTING.rst>`_.
+
+
+Copyright
+---------
+If you are submitting a patch to the existing codebase, the code will be licensed under the same license as FIREWHEEL (or this MC).
+Please review :ref:`LICENSE <license>` for more information.


### PR DESCRIPTION
This creates all of the common workflows for performing FIREWHEEL CI using the [common CI repository](https://github.com/sandialabs/firewheel_ci).