### PR TITLE
style: Use project formatting dependencies and enforce Ruff format checks

### DIFF
--- a/src/firewheel_repo_dns/configure_bind/plugin.py
+++ b/src/firewheel_repo_dns/configure_bind/plugin.py
@@ -78,13 +78,17 @@ class ConfigureBind(AbstractPlugin):
                 )
                 if self.DEBUG:
                     pickle_file = open(
-                        os.path.join(self.zonedir, "pickled_metadata"), "w", encoding="utf-8"
+                        os.path.join(self.zonedir, "pickled_metadata"),
+                        "w",
+                        encoding="utf-8",
                     )
                     pickle_file.write(pickled_metadata)
                     pickle_file.close()
                     # Save the zone data dictionary for easy reading
                     pickle_file = open(
-                        os.path.join(self.zonedir, "zone_dictionary"), "w", encoding="utf-8"
+                        os.path.join(self.zonedir, "zone_dictionary"),
+                        "w",
+                        encoding="utf-8",
                     )
                     pickle_file.write(pprint.pformat(zones))
                     pickle_file.close()
@@ -113,7 +117,9 @@ class ConfigureBind(AbstractPlugin):
             if self.DEBUG:
                 if not zone:
                     zone = "dot."
-                zone_file = open(os.path.join(self.zonedir, zone), "w", encoding="utf-8")
+                zone_file = open(
+                    os.path.join(self.zonedir, zone), "w", encoding="utf-8"
+                )
                 zone_file.write(zone_file_contents)
                 zone_file.close()
 
@@ -175,7 +181,9 @@ class ConfigureBind(AbstractPlugin):
         if self.DEBUG:
             if glue_record:
                 gr_file = open(
-                    os.path.join(self.zonedir, f"{base_domain}{'glue'}"), "w", encoding="utf-8"
+                    os.path.join(self.zonedir, f"{base_domain}{'glue'}"),
+                    "w",
+                    encoding="utf-8",
                 )
                 gr_file.write(glue_record)
                 gr_file.close()
@@ -207,7 +215,11 @@ class ConfigureBind(AbstractPlugin):
 
         if self.DEBUG:
             if glue_record:
-                gr_file = open(os.path.join(self.zonedir, f"{'dot.'}{'glue'}"), "w", encoding="utf-8")
+                gr_file = open(
+                    os.path.join(self.zonedir, f"{'dot.'}{'glue'}"),
+                    "w",
+                    encoding="utf-8",
+                )
                 gr_file.write(glue_record)
                 gr_file.close()
 
@@ -247,7 +259,9 @@ class ConfigureBind(AbstractPlugin):
         if self.DEBUG:
             if not base_domain:
                 base_domain = "dot."
-            ar_file = open(os.path.join(self.zonedir, f"{base_domain}{'a'}"), "w", encoding="utf-8")
+            ar_file = open(
+                os.path.join(self.zonedir, f"{base_domain}{'a'}"), "w", encoding="utf-8"
+            )
             ar_file.write(record)
             ar_file.close()
 

--- a/src/firewheel_repo_dns/populate_zones/plugin.py
+++ b/src/firewheel_repo_dns/populate_zones/plugin.py
@@ -48,9 +48,7 @@ class PopulateZones(AbstractPlugin):
         """
 
         zones = {}
-        self.log.debug(
-            "PTRs requested for %s = %s", dns_server_name, str(hosts_tracked)
-        )
+        self.log.debug("PTRs requested for %s = %s", dns_server_name, hosts_tracked)
 
         vertices = self.g.get_vertices()
         for vertex in vertices:

--- a/tox.ini
+++ b/tox.ini
@@ -20,6 +20,7 @@ commands =
 basepython = python3
 deps = {[testenv:ruff]deps}
 commands =
+    ruff check --select I --fix {toxinidir}/src
     ruff format {toxinidir}/src
 
 # Linters

--- a/tox.ini
+++ b/tox.ini
@@ -43,6 +43,7 @@ basepython = python3
 deps = {[testenv:ruff]deps}
 commands =
     {[testenv:ruff]commands}
+    ruff format --check {toxinidir}/src
 
 [testenv:lint-docs]
 basepython = python3

--- a/tox.ini
+++ b/tox.ini
@@ -11,7 +11,7 @@ passenv =
 
 [testenv:ruff]
 basepython = python3
-deps = ruff==0.8.1
+deps = firewheel[format]
 commands =
     ruff check {posargs}
 


### PR DESCRIPTION
This updates the Ruff linting tox environment to use the project’s formatting dependencies and adds a formatting check for the `src` directory when running `tox -e lint`.

It also applies formatting cleanup across files corresponding to the updated Ruff version to satisfy the linter.